### PR TITLE
feat: support custom resolve-externals code (๑•̀ㅂ•́)و✧

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 package-lock.json
+.DS_Store
+node_modules/
+dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.zip
+lib
+.jscpd/
+.idea/
+.cache/
+index.html
+**/tmp
+.env

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ export default defineConfig({
       vue: 'Vue',
       vuex: 'Vuex',
       'vue-router': 'VueRouter',
-      'element-ui': 'ELEMENT',
+      'element-ui': () => `
+        const E = window.ELEMENT;
+        export default E;
+        export const Message = E.Message;
+        export const MessageBox = E.MessageBox;
+        export const Notification = E.Notification;
+      `,
+      // ...other element-ui members
     }),
   ],
   resolve: {
@@ -47,6 +54,6 @@ export default defineConfig({
 **src**
 ```js
 import Vue from 'vue'
-import ELementUI from 'element-ui'
+import ELementUI, { Message, MessageBox, Notification } from 'element-ui'
 import axios from 'axios'
 ```

--- a/example/react-demo/vite.config.js
+++ b/example/react-demo/vite.config.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { defineConfig } = require('vite')
 const reactRefresh = require('@vitejs/plugin-react-refresh')
-const resolveExternalsPlugin = require('vite-plugin-resolve-externals')
+const resolveExternalsPlugin = require('../..')
 const projectRootDir = path.resolve(__dirname)
 
 // https://vitejs.dev/config/
@@ -11,7 +11,8 @@ export default defineConfig({
     reactRefresh(),
     resolveExternalsPlugin({
       react: 'React',
-      'react-dom': 'ReactDOM',
+      // Return custom resolve-externals code by function
+      'react-dom': () => `const React = window.ReactDOM; export { React as default }`,
     }),
   ],
   resolve: {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/lceric/vite-plugin-resolve-externals/issues"
   },
-  "homepage": "https://github.com/lceric/vite-plugin-resolve-externals#readme"
+  "homepage": "https://github.com/lceric/vite-plugin-resolve-externals#readme",
+  "devDependencies": {
+    "vite": "^2.x.x"
+  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,8 @@
+import { Plugin } from 'vite';
+
+export default resolveExternals;
+declare const resolveExternals: ResolveExternals;
+
+export interface ResolveExternals {
+  (externals: Record<string, string | ((id: string) => string | Promise<string>)>): Plugin[];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,33 @@
 /**
- * vite resolve-externals
+ * @type {import('.').ResolveExternals}
  */
-function resolveExternals(externals = {}) {
-  return {
-    name: 'vite-plugin-resolve-externals',
-    config(config) {
-      const { resolve } = config;
-      Object.assign(externals, resolve.externals);
-      return config;
+module.exports = function resolveExternals(externals = {}) {
+  const name = 'vite-plugin-resolve-externals';
+  return [
+    {
+      name: `${name}:resolveId`,
+      resolveId(id) {
+        if (externals[id]) {
+          // Avoid vite builtin `vite:resolve` plugin
+          return id;
+        }
+      },
     },
-    resolveId(id) {
-      if (externals[id]) {
-        return id;
-      }
-    },
-    load(id) {
-      if (externals[id]) {
-        return `const externals = window.${externals[id]};
-        export default externals`;
-      }
-    },
-  };
-}
+    {
+      name,
+      config(config) {
+        const { resolve } = config;
+        Object.assign(externals, resolve.externals);
+        return config;
+      },
+      load(id) {
+        const fnOrIife = externals[id];
+        if (!fnOrIife) return null;
 
-module.exports = resolveExternals
+        return typeof fnOrIife === 'function'
+          ? fnOrIife(id)
+          : `const M = window['${fnOrIife}']; export default M`;
+      },
+    },
+  ];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ module.exports = function resolveExternals(externals = {}) {
   return [
     {
       name: `${name}:resolveId`,
+      enforce: 'pre',
       resolveId(id) {
         if (externals[id]) {
           // Avoid vite builtin `vite:resolve` plugin


### PR DESCRIPTION
Hey! 👋
大佬你好，首先感谢你提供了这个包。  

npm 下载量已经有点了，但是这个包对 `element-ui` 这种多导出成员的包支持并不好，尤其是在 React 中使用，多成员导出的情况相当的多，就比如我们常用的 `antd` 。。。
鉴于此前我写了一个 `vite-plugin-fast-external` 也借鉴过此包的实现方式，遂想着将自己的思路加到这个包中来。

## 考量点

1. 很多时候，`resolveId()` 可能不会按照预期工作，因为 “裸模块” 会被 Vite 内置的 `vite:resolve` 插件拦截并处理；所以我们可能需要 `enforce: 'pre'` 来绕开这个行为 | https://github.com/caoxiemeihao/vite-plugin-resolve-externals/commit/e86eade9c6c057cd549a8facc6910f0dfbb13412

2. 当一个 external 的包需要支持多成员导出，“固执己见” 的  `window.${externals[id]}` 并不能友好的处理这个场景，那么这个时候；我们可以通过函数的方式向用户开放自定义导出成员 | https://github.com/caoxiemeihao/vite-plugin-resolve-externals/commit/5d573899fff5ae64895dee698aee3c3b831e0fa5
