### PR TITLE
refactor: Avoid vite Pre-building

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,5 +4,5 @@ export default resolveExternals;
 declare const resolveExternals: ResolveExternals;
 
 export interface ResolveExternals {
-  (externals: Record<string, string | ((id: string) => string | Promise<string>)>): Plugin[];
+  (externals: Record<string, string | ((id: string) => string | Promise<string>)>): Plugin;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * @type {import('.').ResolveExternals}
  */
- module.exports = function resolveExternals(externals = {}) {
+module.exports = function resolveExternals(externals = {}) {
   return {
     name: 'vite-plugin-resolve-externals',
     // It should be run before the vite builtin `vite:resolve`
@@ -13,6 +13,9 @@
       }
     },
     config(config) {
+      // Merge externals from `config.resolve`
+      Object.assign(externals, config.resolve.externals);
+
       if (!config.optimizeDeps) config.optimizeDeps = {};
       if (!config.optimizeDeps.exclude) config.optimizeDeps.exclude = [];
 
@@ -23,9 +26,6 @@
       }
       // Avoid vite Pre-building
       config.optimizeDeps.exclude.push(...exclude);
-
-      // Merge externals from `config.resolve`
-      Object.assign(externals, config.resolve.externals);
     },
     load(id) {
       const fnOrIife = externals[id];
@@ -37,4 +37,3 @@
     },
   };
 };
- 


### PR DESCRIPTION
Hey! 👋  
那那个~ 小姐姐这么好说话的，，，我就厚着脸皮再提一个 PR ٩(๑>◡<๑)۶

实际上，上个 PR 只是提前了 `resolveId()` 但并没有提前 `load()`；酱紫如果在用户即想用 `externals` 但是又忘了删除 node_modules 中的包，那么还是会被 Vite 命中的，就不会理会我们的 `resolve-externals` 了。

原因是另外一个问题，Vite 的 Pre-building 会傻乎乎的去找 node_moduels 的包，才不会理会你的 `externals` 也就是说一旦被 Pre-building 找到了包，就会构建到 Vite 的缓存目录 node_modules/.vite 中。那么当加载时候是**缓存优先命中**的，所以我们的 `resolve-externals` 可能不会按照预期工作，所以还要配置下 `optimizeDeps.exclude` 将我们的 `externals` 的排除掉。

综上，这个插件目前我能想到的可能性都在这了~ (๑•̀ㅂ•́)و✧ 